### PR TITLE
Adjust imports and url references post transfer

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -79,7 +79,7 @@ linters-settings:
   goimports:
     # put imports beginning with prefix after 3rd-party packages;
     # it's a comma-separated list of prefixes
-    local-prefixes: sigs.k8s.io/controller-runtime,github.com/yard-turkey/lib-bucket-provisioner
+    local-prefixes: sigs.k8s.io/controller-runtime,github.com/kube-object-storage/lib-bucket-provisioner
   goconst:
     # minimal length of string constant, 3 by default
     min-len: 3

--- a/README.md
+++ b/README.md
@@ -3,15 +3,15 @@ This repo is a temporary placeholder for a general purpose object-store bucket p
 The goal is to eventually move this repo to a Kubernetes repo within _sig-storage/_.
 
 ### Repo Layout
-The overall [bucket provisioning library design](https://github.com/yard-turkey/lib-bucket-provisioner/blob/master/doc/design/object-bucket-lib.md) describes the Custom Resource Definitions, interfaces, and workflows of an `ObjectBucketClaim` and an `ObjectBucket`.
+The overall [bucket provisioning library design](https://github.com/kube-object-storage/lib-bucket-provisioner/blob/master/doc/design/object-bucket-lib.md) describes the Custom Resource Definitions, interfaces, and workflows of an `ObjectBucketClaim` and an `ObjectBucket`.
 This documents is kept up-to-date and reflects the current design and implementation of bucket provisioning library.
 Future designs and considerations have been removed from the design document, and are tracked as _Issues_ with the `enhancement` label.
 
-There are [examples](https://github.com/yard-turkey/lib-bucket-provisioner/blob/master/doc/examples/) showing how object-store provisioners can use this library.
+There are [examples](https://github.com/kube-object-storage/lib-bucket-provisioner/blob/master/doc/examples/) showing how object-store provisioners can use this library.
 
-Library contributors should look [here](https://github.com/yard-turkey/lib-bucket-provisioner/blob/master/hack/README.md) for `make` and directions.
+Library contributors should look [here](https://github.com/kube-object-storage/lib-bucket-provisioner/blob/master/hack/README.md) for `make` and directions.
 
-Provisioner Developers should look [here](https://github.com/yard-turkey/lib-bucket-provisioner/blob/master/doc/examples/sample-how-to-write-provisioner.md) for some guidance/recommendations/tips on how to get started with creating your own Provisioner. 
+Provisioner Developers should look [here](https://github.com/kube-object-storage/lib-bucket-provisioner/blob/master/doc/examples/sample-how-to-write-provisioner.md) for some guidance/recommendations/tips on how to get started with creating your own Provisioner. 
 
 
 ### Feedback and Community Input

--- a/doc/examples/aws-s3-provisioner/README.md
+++ b/doc/examples/aws-s3-provisioner/README.md
@@ -24,7 +24,7 @@ two basic use cases; Administrator and Developer/Application Owner.
 ### Deploy or Run AWS S3 Provisioner on Cluster
 
 #### Normal Pod Deployment Method 1:
-1. Create the ObjectBucket and ObjectBucketClaim [CustomResourceDefinitions](https://github.com/yard-turkey/lib-bucket-provisioner/blob/master/deploy/customResourceDefinitions.yaml).
+1. Create the ObjectBucket and ObjectBucketClaim [CustomResourceDefinitions](https://github.com/kube-object-storage/lib-bucket-provisioner/blob/master/deploy/customResourceDefinitions.yaml).
 
 2. Create a ClusterRoleBinding for the default serviceaccount that will run your provisioner.
 
@@ -36,7 +36,7 @@ two basic use cases; Administrator and Developer/Application Owner.
 # kubectl create clusterrolebinding cluster-admin-aws --clusterrole=cluster-admin --user=system:serviceaccount:s3-prov:default
 ```
 
-3. Deploy the latest [AWS S3 Provisioner](https://github.com/yard-turkey/aws-s3-provisioner/blob/master/examples/awss3provisioner-deployment.yaml) and create a ClusterRoleBinding.
+3. Deploy the latest [AWS S3 Provisioner](https://github.com/kube-object-storage/aws-s3-provisioner/blob/master/examples/awss3provisioner-deployment.yaml) and create a ClusterRoleBinding.
 
 ```yaml
 apiVersion: apps/v1

--- a/doc/examples/ceph-rgw-provisioner/README.md
+++ b/doc/examples/ceph-rgw-provisioner/README.md
@@ -45,7 +45,7 @@ rook-discover-5v92n                                        1/1     Running     0
 # kubectl create clusterrolebinding cluster-admin-rook --clusterrole=cluster-admin --user=system:serviceaccount:rook-ceph:rook-ceph-system
 ```
 
-3. Create your [operator.yaml](https://github.com/yard-turkey/examples-and-blogs/blob/master/examples/rook-ceph-provisioner/operator.yaml) and execute it - note this is a development branch image that you can build and put in docker or quay - the image listed here might be old!
+3. Create your [operator.yaml](https://github.com/kube-object-storage/examples-and-blogs/blob/master/examples/rook-ceph-provisioner/operator.yaml) and execute it - note this is a development branch image that you can build and put in docker or quay - the image listed here might be old!
 
 ```yaml
 

--- a/doc/examples/sample-how-to-write-provisioner.md
+++ b/doc/examples/sample-how-to-write-provisioner.md
@@ -29,13 +29,13 @@ This example will walk through the steps on how to create your own provisioner. 
 example we will be revisiting some of the key concepts and steps we did to
 produce the AWS-S3-Provisioner. 
 
-For additional information on the design of the library take a look [here](https://github.com/yard-turkey/lib-bucket-provisioner/blob/master/doc/design/object-bucket-lib.md)
+For additional information on the design of the library take a look [here](https://github.com/kube-object-storage/lib-bucket-provisioner/blob/master/doc/design/object-bucket-lib.md)
 
-To contribute or view the library code take a look [here](https://github.com/yard-turkey/lib-bucket-provisioner)
+To contribute or view the library code take a look [here](https://github.com/kube-object-storage/lib-bucket-provisioner)
 
 ### Key Concepts
 
-- Library uses the [ObjectBucket and ObjectBucketClaim](https://github.com/yard-turkey/lib-bucket-provisioner/blob/master/deploy/customResourceDefinitions.yaml) CustomResourceDefinition that is very closely modeled after the existing Kubernetes PV and PVC patterns.
+- Library uses the [ObjectBucket and ObjectBucketClaim](https://github.com/kube-object-storage/lib-bucket-provisioner/blob/master/deploy/customResourceDefinitions.yaml) CustomResourceDefinition that is very closely modeled after the existing Kubernetes PV and PVC patterns.
 
 - The Library and Provisoners also use other common Kubernetes Dynamic Provisioning resources, such as StorageClasses, Secrets and ConfigMaps.
 
@@ -52,7 +52,7 @@ section that allows each provisioner flexibility in what is required for it to s
 - Admin might also need to create proper service accounts for the Provisioner to run.
 
 *User:*
-- User creates an [OBC request](https://github.com/yard-turkey/lib-bucket-provisioner/blob/master/deploy/example-claim.yaml) (Similar to a PVC) that points to the StorageClass of the provisioner.
+- User creates an [OBC request](https://github.com/kube-object-storage/lib-bucket-provisioner/blob/master/deploy/example-claim.yaml) (Similar to a PVC) that points to the StorageClass of the provisioner.
 
 *Library/Provisioner:*
 - Watches for all OBC's in all Namespaces, If the provisioner exists, it will queue and work on the request.
@@ -87,16 +87,15 @@ The following sections will lend some guidance on how a provisioner can be devel
 
 ### Project Layout
 A project can be structured in several different ways, this is just one example of a 
-project model that was used with the [AWS S3 Provisioner](https://github.com/yard-turkey/aws-s3-provisioner).
+project model that was used with the [AWS S3 Provisioner](https://github.com/kube-object-storage/aws-s3-provisioner).
 
 #### Create a GitHub Repo
 1. Login to Github and create a personal repository for your project. Our team uses a generic repo where we
-typically put dev projects called [yard-turkey](https://github.com/yard-turkey). And before you ask...yard-turkey has
-no special meaning other than the guy who created it had a bunch of wild turkeys in his back yard during that time.
+typically put dev projects called [kube-object-storage](https://github.com/kube-object-storage).
 
 ```
    Good repo should be easy to remmember and find:
-   https://github.com/<team repo>/<specific app/project name> i.e. /yard-turkey/aws-s3-provisioner
+   https://github.com/<team repo>/<specific app/project name> i.e. /kube-object-storage/aws-s3-provisioner
    
    You can also use your personal repo for dev if you don't have a formal or team repo to use
    https://github.com/<github user>/<specific app/project name> i.e. /screeley44/aws-s3-provisioner
@@ -156,9 +155,9 @@ Now the basic project structure is in place, you can begin building the provisio
 *provisioner*.go file in the *Repo Root*/cmd/ directory.
 ### Import Library and Other Common Packages
 ```
-	"github.com/yard-turkey/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
-	libbkt "github.com/yard-turkey/lib-bucket-provisioner/pkg/provisioner"
-	apibkt "github.com/yard-turkey/lib-bucket-provisioner/pkg/provisioner/api"
+	"github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
+	libbkt "github.com/kube-object-storage/lib-bucket-provisioner/pkg/provisioner"
+	apibkt "github.com/kube-object-storage/lib-bucket-provisioner/pkg/provisioner/api"
 
 	storageV1 "k8s.io/api/storage/v1"
 	"k8s.io/client-go/kubernetes"
@@ -246,7 +245,7 @@ func (p *gcsProvisioner) rtnObjectBkt(bktName string) *v1alpha1.ObjectBucket {
 ### Sample Code
 Take a look at some existing provisioners to get an idea of how these interfaces are implemented and you can
 most likely use these a template to get started, updating where it is appropriate.
-[AWS-S3-Provisioner](https://github.com/yard-turkey/aws-s3-provisioner)
+[AWS-S3-Provisioner](https://github.com/kube-object-storage/aws-s3-provisioner)
 [Rook-Ceph Provisioner](TBD)
 ### Dependency Management
 The Bucket Library uses `client-go v1.11` and `Kubernete v1.14`. If your project uses different versions
@@ -296,7 +295,7 @@ See links above for some guidance on how one might go about doing that.
  # go build -a -o ./bin/aws-s3-provisioner  ./cmd/...
 ```
 
-2. Install the [OB/OBC CRDs](https://github.com/yard-turkey/lib-bucket-provisioner/blob/master/deploy/customResourceDefinitions.yaml) on your cluster.
+2. Install the [OB/OBC CRDs](https://github.com/kube-object-storage/lib-bucket-provisioner/blob/master/deploy/customResourceDefinitions.yaml) on your cluster.
 
 
 3. Push the binary to a remote cluster to test or run it on your local cluster if you have one.
@@ -362,4 +361,4 @@ i.e.
 
 ## Usage Examples
 
-End-to-End [Examples](https://github.com/yard-turkey/examples-and-blogs/tree/master/examples)
+End-to-End [Examples](https://github.com/kube-object-storage/examples-and-blogs/tree/master/examples)

--- a/hack/README.md
+++ b/hack/README.md
@@ -2,7 +2,7 @@
 
 Clone this repo with 
 
-`go get -d github.com/yard-turkey/lib-bucket-provisioner`
+`go get -d github.com/github.com/kube-object-storage/lib-bucket-provisioner`
 
 Then install the dependencies
 

--- a/hack/go.sh
+++ b/hack/go.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 REPO_ROOT="$(readlink -f $(dirname ${BASH_SOURCE})/../)"
-readonly LOCAL_IMPORT="sigs.k8s.io/controller-runtime,github.com/yard-turkey/lib-bucket-provisioner/"
+readonly LOCAL_IMPORT="sigs.k8s.io/controller-runtime,github.com/kube-object-storage/lib-bucket-provisioner/"
 
 readonly PKGS="./pkg/..."
 

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -5,7 +5,7 @@ set -o nounset
 set -o pipefail
 
 REPO_ROOT="$(realpath -LP $(dirname ${BASH_SOURCE})/../)"
-IMPORT_PATH="github.com/yard-turkey/lib-bucket-provisioner"
+IMPORT_PATH="github.com/kube-object-storage/lib-bucket-provisioner"
 
 APIS_DIR=${IMPORT_PATH}/pkg/apis
 CLIENT_DIR=${IMPORT_PATH}/pkg/client

--- a/pkg/apis/objectbucket.io/v1alpha1/register.go
+++ b/pkg/apis/objectbucket.io/v1alpha1/register.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	objectbucketio "github.com/yard-turkey/lib-bucket-provisioner/pkg/apis/objectbucket.io"
+	objectbucketio "github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io"
 )
 
 // SchemeGroupVersion is group version used to register these objects

--- a/pkg/apis/objectbucket.io/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/objectbucket.io/v1alpha1/zz_generated.deepcopy.go
@@ -294,6 +294,11 @@ func (in *ObjectBucketSpec) DeepCopyInto(out *ObjectBucketSpec) {
 		*out = new(v1.PersistentVolumeReclaimPolicy)
 		**out = **in
 	}
+	if in.ClaimRef != nil {
+		in, out := &in.ClaimRef, &out.ClaimRef
+		*out = new(v1.ObjectReference)
+		**out = **in
+	}
 	if in.Connection != nil {
 		in, out := &in.Connection, &out.Connection
 		*out = new(Connection)

--- a/pkg/client/clientset/versioned/clientset.go
+++ b/pkg/client/clientset/versioned/clientset.go
@@ -19,7 +19,7 @@ limitations under the License.
 package versioned
 
 import (
-	objectbucketv1alpha1 "github.com/yard-turkey/lib-bucket-provisioner/pkg/client/clientset/versioned/typed/objectbucket.io/v1alpha1"
+	objectbucketv1alpha1 "github.com/kube-object-storage/lib-bucket-provisioner/pkg/client/clientset/versioned/typed/objectbucket.io/v1alpha1"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"

--- a/pkg/client/clientset/versioned/fake/clientset_generated.go
+++ b/pkg/client/clientset/versioned/fake/clientset_generated.go
@@ -19,9 +19,9 @@ limitations under the License.
 package fake
 
 import (
-	clientset "github.com/yard-turkey/lib-bucket-provisioner/pkg/client/clientset/versioned"
-	objectbucketv1alpha1 "github.com/yard-turkey/lib-bucket-provisioner/pkg/client/clientset/versioned/typed/objectbucket.io/v1alpha1"
-	fakeobjectbucketv1alpha1 "github.com/yard-turkey/lib-bucket-provisioner/pkg/client/clientset/versioned/typed/objectbucket.io/v1alpha1/fake"
+	clientset "github.com/kube-object-storage/lib-bucket-provisioner/pkg/client/clientset/versioned"
+	objectbucketv1alpha1 "github.com/kube-object-storage/lib-bucket-provisioner/pkg/client/clientset/versioned/typed/objectbucket.io/v1alpha1"
+	fakeobjectbucketv1alpha1 "github.com/kube-object-storage/lib-bucket-provisioner/pkg/client/clientset/versioned/typed/objectbucket.io/v1alpha1/fake"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/discovery"

--- a/pkg/client/clientset/versioned/fake/register.go
+++ b/pkg/client/clientset/versioned/fake/register.go
@@ -19,7 +19,7 @@ limitations under the License.
 package fake
 
 import (
-	objectbucketv1alpha1 "github.com/yard-turkey/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
+	objectbucketv1alpha1 "github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/client/clientset/versioned/scheme/register.go
+++ b/pkg/client/clientset/versioned/scheme/register.go
@@ -19,7 +19,7 @@ limitations under the License.
 package scheme
 
 import (
-	objectbucketv1alpha1 "github.com/yard-turkey/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
+	objectbucketv1alpha1 "github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/client/clientset/versioned/typed/objectbucket.io/v1alpha1/fake/fake_objectbucket.go
+++ b/pkg/client/clientset/versioned/typed/objectbucket.io/v1alpha1/fake/fake_objectbucket.go
@@ -19,7 +19,7 @@ limitations under the License.
 package fake
 
 import (
-	v1alpha1 "github.com/yard-turkey/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
+	v1alpha1 "github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/client/clientset/versioned/typed/objectbucket.io/v1alpha1/fake/fake_objectbucket.io_client.go
+++ b/pkg/client/clientset/versioned/typed/objectbucket.io/v1alpha1/fake/fake_objectbucket.io_client.go
@@ -19,7 +19,7 @@ limitations under the License.
 package fake
 
 import (
-	v1alpha1 "github.com/yard-turkey/lib-bucket-provisioner/pkg/client/clientset/versioned/typed/objectbucket.io/v1alpha1"
+	v1alpha1 "github.com/kube-object-storage/lib-bucket-provisioner/pkg/client/clientset/versioned/typed/objectbucket.io/v1alpha1"
 	rest "k8s.io/client-go/rest"
 	testing "k8s.io/client-go/testing"
 )

--- a/pkg/client/clientset/versioned/typed/objectbucket.io/v1alpha1/fake/fake_objectbucketclaim.go
+++ b/pkg/client/clientset/versioned/typed/objectbucket.io/v1alpha1/fake/fake_objectbucketclaim.go
@@ -19,7 +19,7 @@ limitations under the License.
 package fake
 
 import (
-	v1alpha1 "github.com/yard-turkey/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
+	v1alpha1 "github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/client/clientset/versioned/typed/objectbucket.io/v1alpha1/objectbucket.go
+++ b/pkg/client/clientset/versioned/typed/objectbucket.io/v1alpha1/objectbucket.go
@@ -21,8 +21,8 @@ package v1alpha1
 import (
 	"time"
 
-	v1alpha1 "github.com/yard-turkey/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
-	scheme "github.com/yard-turkey/lib-bucket-provisioner/pkg/client/clientset/versioned/scheme"
+	v1alpha1 "github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
+	scheme "github.com/kube-object-storage/lib-bucket-provisioner/pkg/client/clientset/versioned/scheme"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/pkg/client/clientset/versioned/typed/objectbucket.io/v1alpha1/objectbucket.io_client.go
+++ b/pkg/client/clientset/versioned/typed/objectbucket.io/v1alpha1/objectbucket.io_client.go
@@ -19,8 +19,8 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1alpha1 "github.com/yard-turkey/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
-	"github.com/yard-turkey/lib-bucket-provisioner/pkg/client/clientset/versioned/scheme"
+	v1alpha1 "github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
+	"github.com/kube-object-storage/lib-bucket-provisioner/pkg/client/clientset/versioned/scheme"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	rest "k8s.io/client-go/rest"
 )

--- a/pkg/client/clientset/versioned/typed/objectbucket.io/v1alpha1/objectbucketclaim.go
+++ b/pkg/client/clientset/versioned/typed/objectbucket.io/v1alpha1/objectbucketclaim.go
@@ -21,8 +21,8 @@ package v1alpha1
 import (
 	"time"
 
-	v1alpha1 "github.com/yard-turkey/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
-	scheme "github.com/yard-turkey/lib-bucket-provisioner/pkg/client/clientset/versioned/scheme"
+	v1alpha1 "github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
+	scheme "github.com/kube-object-storage/lib-bucket-provisioner/pkg/client/clientset/versioned/scheme"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/pkg/client/informers/externalversions/factory.go
+++ b/pkg/client/informers/externalversions/factory.go
@@ -23,9 +23,9 @@ import (
 	sync "sync"
 	time "time"
 
-	versioned "github.com/yard-turkey/lib-bucket-provisioner/pkg/client/clientset/versioned"
-	internalinterfaces "github.com/yard-turkey/lib-bucket-provisioner/pkg/client/informers/externalversions/internalinterfaces"
-	objectbucketio "github.com/yard-turkey/lib-bucket-provisioner/pkg/client/informers/externalversions/objectbucket.io"
+	versioned "github.com/kube-object-storage/lib-bucket-provisioner/pkg/client/clientset/versioned"
+	internalinterfaces "github.com/kube-object-storage/lib-bucket-provisioner/pkg/client/informers/externalversions/internalinterfaces"
+	objectbucketio "github.com/kube-object-storage/lib-bucket-provisioner/pkg/client/informers/externalversions/objectbucket.io"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/client/informers/externalversions/generic.go
+++ b/pkg/client/informers/externalversions/generic.go
@@ -21,7 +21,7 @@ package externalversions
 import (
 	"fmt"
 
-	v1alpha1 "github.com/yard-turkey/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
+	v1alpha1 "github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	cache "k8s.io/client-go/tools/cache"
 )

--- a/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -21,7 +21,7 @@ package internalinterfaces
 import (
 	time "time"
 
-	versioned "github.com/yard-turkey/lib-bucket-provisioner/pkg/client/clientset/versioned"
+	versioned "github.com/kube-object-storage/lib-bucket-provisioner/pkg/client/clientset/versioned"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	cache "k8s.io/client-go/tools/cache"

--- a/pkg/client/informers/externalversions/objectbucket.io/interface.go
+++ b/pkg/client/informers/externalversions/objectbucket.io/interface.go
@@ -19,8 +19,8 @@ limitations under the License.
 package objectbucket
 
 import (
-	internalinterfaces "github.com/yard-turkey/lib-bucket-provisioner/pkg/client/informers/externalversions/internalinterfaces"
-	v1alpha1 "github.com/yard-turkey/lib-bucket-provisioner/pkg/client/informers/externalversions/objectbucket.io/v1alpha1"
+	internalinterfaces "github.com/kube-object-storage/lib-bucket-provisioner/pkg/client/informers/externalversions/internalinterfaces"
+	v1alpha1 "github.com/kube-object-storage/lib-bucket-provisioner/pkg/client/informers/externalversions/objectbucket.io/v1alpha1"
 )
 
 // Interface provides access to each of this group's versions.

--- a/pkg/client/informers/externalversions/objectbucket.io/v1alpha1/interface.go
+++ b/pkg/client/informers/externalversions/objectbucket.io/v1alpha1/interface.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	internalinterfaces "github.com/yard-turkey/lib-bucket-provisioner/pkg/client/informers/externalversions/internalinterfaces"
+	internalinterfaces "github.com/kube-object-storage/lib-bucket-provisioner/pkg/client/informers/externalversions/internalinterfaces"
 )
 
 // Interface provides access to all the informers in this group version.

--- a/pkg/client/informers/externalversions/objectbucket.io/v1alpha1/objectbucket.go
+++ b/pkg/client/informers/externalversions/objectbucket.io/v1alpha1/objectbucket.go
@@ -21,10 +21,10 @@ package v1alpha1
 import (
 	time "time"
 
-	objectbucketiov1alpha1 "github.com/yard-turkey/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
-	versioned "github.com/yard-turkey/lib-bucket-provisioner/pkg/client/clientset/versioned"
-	internalinterfaces "github.com/yard-turkey/lib-bucket-provisioner/pkg/client/informers/externalversions/internalinterfaces"
-	v1alpha1 "github.com/yard-turkey/lib-bucket-provisioner/pkg/client/listers/objectbucket.io/v1alpha1"
+	objectbucketiov1alpha1 "github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
+	versioned "github.com/kube-object-storage/lib-bucket-provisioner/pkg/client/clientset/versioned"
+	internalinterfaces "github.com/kube-object-storage/lib-bucket-provisioner/pkg/client/informers/externalversions/internalinterfaces"
+	v1alpha1 "github.com/kube-object-storage/lib-bucket-provisioner/pkg/client/listers/objectbucket.io/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/pkg/client/informers/externalversions/objectbucket.io/v1alpha1/objectbucketclaim.go
+++ b/pkg/client/informers/externalversions/objectbucket.io/v1alpha1/objectbucketclaim.go
@@ -21,10 +21,10 @@ package v1alpha1
 import (
 	time "time"
 
-	objectbucketiov1alpha1 "github.com/yard-turkey/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
-	versioned "github.com/yard-turkey/lib-bucket-provisioner/pkg/client/clientset/versioned"
-	internalinterfaces "github.com/yard-turkey/lib-bucket-provisioner/pkg/client/informers/externalversions/internalinterfaces"
-	v1alpha1 "github.com/yard-turkey/lib-bucket-provisioner/pkg/client/listers/objectbucket.io/v1alpha1"
+	objectbucketiov1alpha1 "github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
+	versioned "github.com/kube-object-storage/lib-bucket-provisioner/pkg/client/clientset/versioned"
+	internalinterfaces "github.com/kube-object-storage/lib-bucket-provisioner/pkg/client/informers/externalversions/internalinterfaces"
+	v1alpha1 "github.com/kube-object-storage/lib-bucket-provisioner/pkg/client/listers/objectbucket.io/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/pkg/client/listers/objectbucket.io/v1alpha1/objectbucket.go
+++ b/pkg/client/listers/objectbucket.io/v1alpha1/objectbucket.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1alpha1 "github.com/yard-turkey/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
+	v1alpha1 "github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"

--- a/pkg/client/listers/objectbucket.io/v1alpha1/objectbucketclaim.go
+++ b/pkg/client/listers/objectbucket.io/v1alpha1/objectbucketclaim.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1alpha1 "github.com/yard-turkey/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
+	v1alpha1 "github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"

--- a/pkg/provisioner/api/provisioner.go
+++ b/pkg/provisioner/api/provisioner.go
@@ -3,7 +3,7 @@ package api
 import (
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/yard-turkey/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
+	"github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
 )
 
 // All provisioners must implement the Provisioner interface which defines the

--- a/pkg/provisioner/controller.go
+++ b/pkg/provisioner/controller.go
@@ -13,12 +13,12 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 
-	"github.com/yard-turkey/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
-	"github.com/yard-turkey/lib-bucket-provisioner/pkg/client/clientset/versioned"
-	informers "github.com/yard-turkey/lib-bucket-provisioner/pkg/client/informers/externalversions/objectbucket.io/v1alpha1"
-	listers "github.com/yard-turkey/lib-bucket-provisioner/pkg/client/listers/objectbucket.io/v1alpha1"
-	"github.com/yard-turkey/lib-bucket-provisioner/pkg/provisioner/api"
-	pErr "github.com/yard-turkey/lib-bucket-provisioner/pkg/provisioner/api/errors"
+	"github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
+	"github.com/kube-object-storage/lib-bucket-provisioner/pkg/client/clientset/versioned"
+	informers "github.com/kube-object-storage/lib-bucket-provisioner/pkg/client/informers/externalversions/objectbucket.io/v1alpha1"
+	listers "github.com/kube-object-storage/lib-bucket-provisioner/pkg/client/listers/objectbucket.io/v1alpha1"
+	"github.com/kube-object-storage/lib-bucket-provisioner/pkg/provisioner/api"
+	pErr "github.com/kube-object-storage/lib-bucket-provisioner/pkg/provisioner/api/errors"
 )
 
 type controller interface {

--- a/pkg/provisioner/fakeinterface_test.go
+++ b/pkg/provisioner/fakeinterface_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	// "sigs.k8s.io/Controller-runtime/pkg/client/fake"
 
-	"github.com/yard-turkey/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
-	"github.com/yard-turkey/lib-bucket-provisioner/pkg/provisioner/api"
+	"github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
+	"github.com/kube-object-storage/lib-bucket-provisioner/pkg/provisioner/api"
 )
 
 type fakeProvisioner struct{}

--- a/pkg/provisioner/helpers.go
+++ b/pkg/provisioner/helpers.go
@@ -11,8 +11,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
-	"github.com/yard-turkey/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
-	"github.com/yard-turkey/lib-bucket-provisioner/pkg/client/clientset/versioned"
+	"github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
+	"github.com/kube-object-storage/lib-bucket-provisioner/pkg/client/clientset/versioned"
 )
 
 func makeObjectReference(claim *v1alpha1.ObjectBucketClaim) *corev1.ObjectReference {

--- a/pkg/provisioner/helpers_test.go
+++ b/pkg/provisioner/helpers_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/yard-turkey/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
-	externalFake "github.com/yard-turkey/lib-bucket-provisioner/pkg/client/clientset/versioned/fake"
-	"github.com/yard-turkey/lib-bucket-provisioner/pkg/provisioner/api"
+	"github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
+	externalFake "github.com/kube-object-storage/lib-bucket-provisioner/pkg/client/clientset/versioned/fake"
+	"github.com/kube-object-storage/lib-bucket-provisioner/pkg/provisioner/api"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/pkg/provisioner/log.go
+++ b/pkg/provisioner/log.go
@@ -4,7 +4,7 @@ import (
 	"github.com/go-logr/logr"
 	"k8s.io/klog/klogr"
 
-	"github.com/yard-turkey/lib-bucket-provisioner/pkg/provisioner/api"
+	"github.com/kube-object-storage/lib-bucket-provisioner/pkg/provisioner/api"
 )
 
 var (

--- a/pkg/provisioner/manager.go
+++ b/pkg/provisioner/manager.go
@@ -8,9 +8,9 @@ import (
 	"k8s.io/klog"
 	"k8s.io/klog/klogr"
 
-	"github.com/yard-turkey/lib-bucket-provisioner/pkg/client/clientset/versioned"
-	informers "github.com/yard-turkey/lib-bucket-provisioner/pkg/client/informers/externalversions"
-	"github.com/yard-turkey/lib-bucket-provisioner/pkg/provisioner/api"
+	"github.com/kube-object-storage/lib-bucket-provisioner/pkg/client/clientset/versioned"
+	informers "github.com/kube-object-storage/lib-bucket-provisioner/pkg/client/informers/externalversions"
+	"github.com/kube-object-storage/lib-bucket-provisioner/pkg/provisioner/api"
 )
 
 // Controller is the first iteration of our internal provisioning

--- a/pkg/provisioner/resourcehandlers.go
+++ b/pkg/provisioner/resourcehandlers.go
@@ -7,15 +7,15 @@ import (
 
 	"k8s.io/client-go/kubernetes"
 
-	"github.com/yard-turkey/lib-bucket-provisioner/pkg/client/clientset/versioned"
+	"github.com/kube-object-storage/lib-bucket-provisioner/pkg/client/clientset/versioned"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 
-	"github.com/yard-turkey/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
-	"github.com/yard-turkey/lib-bucket-provisioner/pkg/provisioner/api"
+	"github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
+	"github.com/kube-object-storage/lib-bucket-provisioner/pkg/provisioner/api"
 )
 
 const (
@@ -235,7 +235,7 @@ func updateClaim(c versioned.Interface, obc *v1alpha1.ObjectBucketClaim, retryIn
 
 func updateObjectBucketClaimPhase(c versioned.Interface, obc *v1alpha1.ObjectBucketClaim, phase v1alpha1.ObjectBucketClaimStatusPhase, retryInterval, retryTimeout time.Duration) (result *v1alpha1.ObjectBucketClaim, err error) {
 	logD.Info("updating status:", "obc", obc.Namespace+"/"+obc.Name, "old status",
-		 obc.Status.Phase, "new status", phase)
+		obc.Status.Phase, "new status", phase)
 	obc.Status.Phase = phase
 
 	err = wait.PollImmediate(retryInterval, retryTimeout, func() (bool, error) {

--- a/pkg/provisioner/resourcehandlers_test.go
+++ b/pkg/provisioner/resourcehandlers_test.go
@@ -13,8 +13,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 
-	"github.com/yard-turkey/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
-	externalFake "github.com/yard-turkey/lib-bucket-provisioner/pkg/client/clientset/versioned/fake"
+	"github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
+	externalFake "github.com/kube-object-storage/lib-bucket-provisioner/pkg/client/clientset/versioned/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 


### PR DESCRIPTION
Replaced all references to yard-turkey in the project's docs, scripts, and code with kube-object-storage, following the org transfer.

Signed-off-by: Jon Cope <jcope@redhat.com>