### PR TITLE
CRD's additionalPrinterColumns for kubectl get

### DIFF
--- a/deploy/customResourceDefinitions.yaml
+++ b/deploy/customResourceDefinitions.yaml
@@ -19,6 +19,18 @@ spec:
   scope: Cluster
   subresources:
     status: {}
+  additionalPrinterColumns:
+  - JSONPath: .spec.storageClassName
+    description: StorageClass
+    name: StorageClass
+    type: string
+  - JSONPath: .status.phase
+    description: Phase
+    name: Phase
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -41,3 +53,27 @@ spec:
   scope: Namespaced
   subresources:
     status: {}
+  additionalPrinterColumns:
+  - JSONPath: .spec.storageClassName
+    description: StorageClass
+    name: StorageClass
+    type: string
+  - JSONPath: .spec.claimRef.namespace
+    description: ClaimNamespace
+    name: ClaimNamespace
+    type: string
+  - JSONPath: .spec.claimRef.name
+    description: ClaimName
+    name: ClaimName
+    type: string
+  - JSONPath: .spec.reclaimPolicy
+    description: ReclaimPolicy
+    name: ReclaimPolicy
+    type: string
+  - JSONPath: .status.phase
+    description: Phase
+    name: Phase
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date

--- a/pkg/apis/objectbucket.io/v1alpha1/objectbucket_types.go
+++ b/pkg/apis/objectbucket.io/v1alpha1/objectbucket_types.go
@@ -132,12 +132,17 @@ type ObjectBucketStatus struct {
 	Conditions corev1.ConditionStatus  `json:"conditions"`
 }
 
+// ObjectBucket is the Schema for the objectbuckets API
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:openapi-gen=true
-
-// ObjectBucket is the Schema for the objectbuckets API
+// +kubebuilder:printcolumn:name="StorageClass",type="string",JSONPath=".spec.storageClassName",description="StorageClass"
+// +kubebuilder:printcolumn:name="ClaimNamespace",type="string",JSONPath=".spec.claimRef.namespace",description="ClaimNamespace"
+// +kubebuilder:printcolumn:name="ClaimName",type="string",JSONPath=".spec.claimRef.name",description="ClaimName"
+// +kubebuilder:printcolumn:name="ReclaimPolicy",type="string",JSONPath=".spec.reclaimPolicy",description="ReclaimPolicy"
+// +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="Phase"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type ObjectBucket struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -146,9 +151,8 @@ type ObjectBucket struct {
 	Status ObjectBucketStatus `json:"status,omitempty"`
 }
 
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-
 // ObjectBucketList contains a list of ObjectBucket
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object2
 type ObjectBucketList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/pkg/apis/objectbucket.io/v1alpha1/objectbucketclaim_types.go
+++ b/pkg/apis/objectbucket.io/v1alpha1/objectbucketclaim_types.go
@@ -96,11 +96,13 @@ type ObjectBucketClaimStatus struct {
 	Phase ObjectBucketClaimStatusPhase
 }
 
+// ObjectBucketClaim is the Schema for the objectbucketclaims API
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:openapi-gen=true
-
-// ObjectBucketClaim is the Schema for the objectbucketclaims API
+// +kubebuilder:printcolumn:name="StorageClass",type="string",JSONPath=".spec.storageClassName",description="StorageClass"
+// +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="Phase"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type ObjectBucketClaim struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -109,9 +111,8 @@ type ObjectBucketClaim struct {
 	Status ObjectBucketClaimStatus `json:"status,omitempty"`
 }
 
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-
 // ObjectBucketClaimList contains a list of ObjectBucketClaim
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type ObjectBucketClaimList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
Defined the additionalPrinterColumns using kubebuilder marker comments, see:
https://book.kubebuilder.io/reference/generating-crd.html

However, since the CRD's of the lib are not generated by kubebuilder, I manually applied this change to the crds file.