### PR TITLE
fix typo/formatting from pr 141

### DIFF
--- a/pkg/apis/objectbucket.io/v1alpha1/objectbucket_types.go
+++ b/pkg/apis/objectbucket.io/v1alpha1/objectbucket_types.go
@@ -132,7 +132,6 @@ type ObjectBucketStatus struct {
 	Conditions corev1.ConditionStatus  `json:"conditions"`
 }
 
-// ObjectBucket is the Schema for the objectbuckets API
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -143,6 +142,8 @@ type ObjectBucketStatus struct {
 // +kubebuilder:printcolumn:name="ReclaimPolicy",type="string",JSONPath=".spec.reclaimPolicy",description="ReclaimPolicy"
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="Phase"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+
+// ObjectBucket is the Schema for the objectbuckets API
 type ObjectBucket struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -151,8 +152,9 @@ type ObjectBucket struct {
 	Status ObjectBucketStatus `json:"status,omitempty"`
 }
 
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
 // ObjectBucketList contains a list of ObjectBucket
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object2
 type ObjectBucketList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/pkg/apis/objectbucket.io/v1alpha1/objectbucketclaim_types.go
+++ b/pkg/apis/objectbucket.io/v1alpha1/objectbucketclaim_types.go
@@ -110,13 +110,14 @@ type ObjectBucketClaimStatus struct {
 	Phase ObjectBucketClaimStatusPhase `json:"phase,omitempty"`
 }
 
-// ObjectBucketClaim is the Schema for the objectbucketclaims API
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:openapi-gen=true
 // +kubebuilder:printcolumn:name="StorageClass",type="string",JSONPath=".spec.storageClassName",description="StorageClass"
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="Phase"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+
+// ObjectBucketClaim is the Schema for the objectbucketclaims API
 type ObjectBucketClaim struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -125,8 +126,9 @@ type ObjectBucketClaim struct {
 	Status ObjectBucketClaimStatus `json:"status,omitempty"`
 }
 
-// ObjectBucketClaimList contains a list of ObjectBucketClaim
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
+// ObjectBucketClaimList contains a list of ObjectBucketClaim
 type ObjectBucketClaimList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
Fixes a typo and code generation format issues from pr #141 
After 141 was merged _hack/update-codegen.sh_ failed with this error:
```
$ hack/update-codegen.sh 
Generating deepcopy funcs
F0904 17:16:10.434242    8135 main.go:82] Error: Failed executing generator: some packages had errors:
type "k8s.io/apimachinery/pkg/runtime.Object2" in k8s:deepcopy-gen:interfaces tag of type k8s.io/apimachinery/pkg/runtime.Object2 is not an interface, but: ""
```
This was due to the _Object2_ typo.
But also the format of the gen tags didn't match the pattern expected by [codegen](https://blog.openshift.com/kubernetes-deep-dive-code-generation-customresources/)

Signed-off-by: jeffvance <jeff.h.vance@gmail.com>

@copejon @guymguym 