### PR TITLE
disable golangci-ling go mod support

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,6 +30,8 @@ run:
   skip-files:
     - "zz_generated.*"
 
+  modules-download-mode: vendor
+
 # output configuration options
 output:
   # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"


### PR DESCRIPTION
Golangci-lint will mistakenly build the project using local mods of dependencies if present.  Disable this behavior to force it to build from vendor.