### PR TITLE
Custom labels

### DIFF
--- a/pkg/provisioner/controller.go
+++ b/pkg/provisioner/controller.go
@@ -249,7 +249,6 @@ func (c *Controller) handleProvisionClaim(key string, obc *v1alpha1.ObjectBucket
 		secret    *corev1.Secret
 		configMap *corev1.ConfigMap
 	)
-	obcNsName := obc.Namespace + "/" + obc.Name
 
 	// first step is to update the OBC's status to pending
 	obc, err = updateObjectBucketClaimPhase(
@@ -259,7 +258,7 @@ func (c *Controller) handleProvisionClaim(key string, obc *v1alpha1.ObjectBucket
 		defaultRetryBaseInterval,
 		defaultRetryTimeout)
 	if err != nil {
-		return fmt.Errorf("error updating OBC %q's status to %q: %v", obcNsName, v1alpha1.ObjectBucketClaimStatusPhasePending, err)
+		return fmt.Errorf("error updating OBC status to %q: %v", v1alpha1.ObjectBucketClaimStatusPhasePending, err)
 	}
 
 	// set finalizer in OBC so that resources can be cleaned up when the obc is deleted
@@ -340,7 +339,7 @@ func (c *Controller) handleProvisionClaim(key string, obc *v1alpha1.ObjectBucket
 		defaultRetryBaseInterval,
 		defaultRetryTimeout)
 	if err != nil {
-		return fmt.Errorf("error creating secret for OBC %q: %v", obcNsName, err)
+		return fmt.Errorf("error creating secret for OBC: %v", err)
 	}
 	configMap, err = createConfigMap(
 		obc,
@@ -350,7 +349,7 @@ func (c *Controller) handleProvisionClaim(key string, obc *v1alpha1.ObjectBucket
 		defaultRetryBaseInterval,
 		defaultRetryTimeout)
 	if err != nil {
-		return fmt.Errorf("error creating configmap for OBC %q: %v", obcNsName, err)
+		return fmt.Errorf("error creating configmap for OBC: %v", err)
 	}
 
 	// Create OB
@@ -378,7 +377,7 @@ func (c *Controller) handleProvisionClaim(key string, obc *v1alpha1.ObjectBucket
 		defaultRetryBaseInterval,
 		defaultRetryTimeout)
 	if err != nil {
-		return fmt.Errorf("error updating OB %q's status to %q:", ob.Name, v1alpha1.ObjectBucketStatusPhaseBound, err)
+		return fmt.Errorf("error updating OB %q's status to %q: %v", ob.Name, v1alpha1.ObjectBucketStatusPhaseBound, err)
 	}
 
 	// update OBC
@@ -390,7 +389,7 @@ func (c *Controller) handleProvisionClaim(key string, obc *v1alpha1.ObjectBucket
 		defaultRetryBaseInterval,
 		defaultRetryTimeout)
 	if err != nil {
-		return fmt.Errorf("error updating OBC %q: %v", obcNsName, err)
+		return fmt.Errorf("error updating OBC: %v", err)
 	}
 	obc, err = updateObjectBucketClaimPhase(
 		c.libClientset,
@@ -399,7 +398,7 @@ func (c *Controller) handleProvisionClaim(key string, obc *v1alpha1.ObjectBucket
 		defaultRetryBaseInterval,
 		defaultRetryTimeout)
 	if err != nil {
-		return fmt.Errorf("error updating OBC %q's status to %q: %v", obcNsName, v1alpha1.ObjectBucketClaimStatusPhaseBound, err)
+		return fmt.Errorf("error updating OBC %q's status to: %v", v1alpha1.ObjectBucketClaimStatusPhaseBound, err)
 	}
 
 	log.Info("provisioning succeeded")

--- a/pkg/provisioner/controller.go
+++ b/pkg/provisioner/controller.go
@@ -40,6 +40,7 @@ import (
 
 type controller interface {
 	Start(<-chan struct{}) error
+	SetLabels(map[string]string)
 }
 
 // Provisioner is a CRD Controller responsible for executing the Reconcile() function in response to OB and OBC events.
@@ -52,6 +53,8 @@ type Controller struct {
 	obcHasSynced cache.InformerSynced
 	obHasSynced  cache.InformerSynced
 	queue        workqueue.RateLimitingInterface
+
+	provisionerLabels map[string]string
 
 	provisioner     api.Provisioner
 	provisionerName string
@@ -101,16 +104,6 @@ func NewController(provisionerName string, provisioner api.Provisioner, clientse
 	return ctrl
 }
 
-func (c *Controller) enqueueOBC(obj interface{}) {
-	var key string
-	var err error
-	if key, err = cache.MetaNamespaceKeyFunc(obj); err != nil {
-		utilruntime.HandleError(err)
-		return
-	}
-	c.queue.AddRateLimited(key)
-}
-
 func (c *Controller) Start(stopCh <-chan struct{}) error {
 	defer utilruntime.HandleCrash()
 	defer c.queue.ShutDown()
@@ -122,6 +115,20 @@ func (c *Controller) Start(stopCh <-chan struct{}) error {
 
 	<-stopCh
 	return nil
+}
+
+func (c *Controller) SetLabels(labels map[string]string) {
+	c.provisionerLabels = labels
+}
+
+func (c *Controller) enqueueOBC(obj interface{}) {
+	var key string
+	var err error
+	if key, err = cache.MetaNamespaceKeyFunc(obj); err != nil {
+		utilruntime.HandleError(err)
+		return
+	}
+	c.queue.AddRateLimited(key)
 }
 
 func (c *Controller) runWorker() {
@@ -181,7 +188,7 @@ func (c *Controller) processNextItemInQueue() bool {
 // Reconcile implements the Reconciler interface. This function contains the business logic
 // of the OBC Controller.
 // Note: the obc obtained from the key is not expected to be nil. In other words, this func is
-//   not called when informers detect an object is missing and trigger a formal delete event. 
+//   not called when informers detect an object is missing and trigger a formal delete event.
 //   Instead, delete is indicated by the deletionTimestamp being non-nil on an update event.
 func (c *Controller) syncHandler(key string) error {
 
@@ -245,12 +252,18 @@ func (c *Controller) handleProvisionClaim(key string, obc *v1alpha1.ObjectBucket
 	obcNsName := obc.Namespace + "/" + obc.Name
 
 	// first step is to update the OBC's status to pending
-	if obc, err = updateObjectBucketClaimPhase(c.libClientset, obc, v1alpha1.ObjectBucketClaimStatusPhasePending, defaultRetryBaseInterval, defaultRetryTimeout); err != nil {
+	obc, err = updateObjectBucketClaimPhase(
+		c.libClientset,
+		obc,
+		v1alpha1.ObjectBucketClaimStatusPhasePending,
+		defaultRetryBaseInterval,
+		defaultRetryTimeout)
+	if err != nil {
 		return fmt.Errorf("error updating OBC %q's status to %q: %v", obcNsName, v1alpha1.ObjectBucketClaimStatusPhasePending, err)
 	}
 
 	// set finalizer in OBC so that resources can be cleaned up when the obc is deleted
-	if err = c.protectOBC(obc); err != nil {
+	if err = c.setOBCMetaFields(obc); err != nil {
 		return err
 	}
 
@@ -319,10 +332,24 @@ func (c *Controller) handleProvisionClaim(key string, obc *v1alpha1.ObjectBucket
 	}
 
 	// create Secret and ConfigMap
-	if secret, err = createSecret(obc, ob.Spec.Authentication, c.clientset, defaultRetryBaseInterval, defaultRetryTimeout); err != nil {
+	secret, err = createSecret(
+		obc,
+		ob.Spec.Authentication,
+		c.provisionerLabels,
+		c.clientset,
+		defaultRetryBaseInterval,
+		defaultRetryTimeout)
+	if err != nil {
 		return fmt.Errorf("error creating secret for OBC %q: %v", obcNsName, err)
 	}
-	if configMap, err = createConfigMap(obc, ob.Spec.Endpoint, c.clientset, defaultRetryBaseInterval, defaultRetryTimeout); err != nil {
+	configMap, err = createConfigMap(
+		obc,
+		ob.Spec.Endpoint,
+		c.provisionerLabels,
+		c.clientset,
+		defaultRetryBaseInterval,
+		defaultRetryTimeout)
+	if err != nil {
 		return fmt.Errorf("error creating configmap for OBC %q: %v", obcNsName, err)
 	}
 
@@ -334,21 +361,44 @@ func (c *Controller) handleProvisionClaim(key string, obc *v1alpha1.ObjectBucket
 	ob.Spec.ClaimRef, err = claimRefForKey(key, c.libClientset)
 	ob.Spec.ReclaimPolicy = options.ReclaimPolicy
 	ob.SetFinalizers([]string{finalizer})
+	ob.SetLabels(c.provisionerLabels)
 
-	if ob, err = createObjectBucket(ob, c.libClientset, defaultRetryBaseInterval, defaultRetryTimeout); err != nil {
+	ob, err = createObjectBucket(
+		ob,
+		c.libClientset,
+		defaultRetryBaseInterval,
+		defaultRetryTimeout)
+	if err != nil {
 		return fmt.Errorf("error creating OB %q: %v", ob.Name, err)
 	}
-	if ob, err = updateObjectBucketPhase(c.libClientset, ob, v1alpha1.ObjectBucketStatusPhaseBound, defaultRetryBaseInterval, defaultRetryTimeout); err != nil {
+	ob, err = updateObjectBucketPhase(
+		c.libClientset,
+		ob,
+		v1alpha1.ObjectBucketStatusPhaseBound,
+		defaultRetryBaseInterval,
+		defaultRetryTimeout)
+	if err != nil {
 		return fmt.Errorf("error updating OB %q's status to %q:", ob.Name, v1alpha1.ObjectBucketStatusPhaseBound, err)
 	}
 
 	// update OBC
 	obc.Spec.ObjectBucketName = ob.Name
 	obc.Spec.BucketName = bucketName
-	if obc, err = updateClaim(c.libClientset, obc, defaultRetryBaseInterval, defaultRetryTimeout); err != nil {
+	obc, err = updateClaim(
+		c.libClientset,
+		obc,
+		defaultRetryBaseInterval,
+		defaultRetryTimeout)
+	if err != nil {
 		return fmt.Errorf("error updating OBC %q: %v", obcNsName, err)
 	}
-	if obc, err = updateObjectBucketClaimPhase(c.libClientset, obc, v1alpha1.ObjectBucketClaimStatusPhaseBound, defaultRetryBaseInterval, defaultRetryTimeout); err != nil {
+	obc, err = updateObjectBucketClaimPhase(
+		c.libClientset,
+		obc,
+		v1alpha1.ObjectBucketClaimStatusPhaseBound,
+		defaultRetryBaseInterval,
+		defaultRetryTimeout)
+	if err != nil {
 		return fmt.Errorf("error updating OBC %q's status to %q: %v", obcNsName, v1alpha1.ObjectBucketClaimStatusPhaseBound, err)
 	}
 
@@ -464,21 +514,24 @@ func (c *Controller) deleteResources(ob *v1alpha1.ObjectBucket, cm *corev1.Confi
 }
 
 // Add a finalizer to the OBC so that resource deletion can be orchestrated.
-func (c *Controller) protectOBC(obc *v1alpha1.ObjectBucketClaim) (err error) {
+// Add custom labels to the OBC.
+func (c *Controller) setOBCMetaFields(obc *v1alpha1.ObjectBucketClaim) (err error) {
 
 	clib := c.libClientset
-	obcNsName := obc.Namespace + "/" + obc.Name
 
+	logD.Info("getting OBC to set metadata fields")
 	obc, err = clib.ObjectbucketV1alpha1().ObjectBucketClaims(obc.Namespace).Get(obc.Name, metav1.GetOptions{})
 	if err != nil {
-		return fmt.Errorf("unable to Get obc %q for protection: %v", obcNsName, err)
+		return fmt.Errorf("error getting unconfigured obc: %v", err)
 	}
 
-	logD.Info("adding obc finalizer")
 	obc.SetFinalizers([]string{finalizer})
-	obc, err = clib.ObjectbucketV1alpha1().ObjectBucketClaims(obc.Namespace).Update(obc)
+	obc.SetLabels(c.provisionerLabels)
+
+	logD.Info("updating OBC metadata")
+	obc, err = updateClaim(clib, obc, defaultRetryBaseInterval, defaultRetryTimeout)
 	if err != nil {
-		return fmt.Errorf("unable to Update obc %q for protection: %v", obcNsName, err)
+		return fmt.Errorf("error configuring obc metadata: %v", err)
 	}
 
 	return nil


### PR DESCRIPTION
This PR introduces a backwards compatible change to enable the setting of labels on resources managed by the provisioner.  This is accomplished by adding a`SetLabels(map[string]string)` method to the `Provisioner` interface.  The method statically assigns the map to the controller for access during sync operations.

The purpose of this change is to ease api resource management and provisioner development. 

Also include some minor refactoring for readability.

fixes #133, #57 and replaces pr #140 

Signed-off-by: Jon Cope <jcope@redhat.com>