### PR TITLE
Unexport internal controller

### DIFF
--- a/pkg/provisioner/controller.go
+++ b/pkg/provisioner/controller.go
@@ -42,8 +42,8 @@ type controller interface {
 	Start(<-chan struct{}) error
 }
 
-// Provisioner is a CRD Controller responsible for executing the Reconcile() function in response to OB and OBC events.
-type Controller struct {
+// Provisioner is a CRD obcController responsible for executing the Reconcile() function in response to OB and OBC events.
+type obcController struct {
 	clientset    kubernetes.Interface
 	libClientset versioned.Interface
 	obcLister    listers.ObjectBucketClaimLister
@@ -57,10 +57,10 @@ type Controller struct {
 	provisionerName string
 }
 
-var _ controller = &Controller{}
+var _ controller = &obcController{}
 
-func NewController(provisionerName string, provisioner api.Provisioner, clientset kubernetes.Interface, crdClientSet versioned.Interface, obcInformer informers.ObjectBucketClaimInformer, obInformer informers.ObjectBucketInformer) *Controller {
-	ctrl := &Controller{
+func newController(provisionerName string, provisioner api.Provisioner, clientset kubernetes.Interface, crdClientSet versioned.Interface, obcInformer informers.ObjectBucketClaimInformer, obInformer informers.ObjectBucketInformer) *obcController {
+	ctrl := &obcController{
 		clientset:       clientset,
 		libClientset:    crdClientSet,
 		obcLister:       obcInformer.Lister(),
@@ -101,7 +101,7 @@ func NewController(provisionerName string, provisioner api.Provisioner, clientse
 	return ctrl
 }
 
-func (c *Controller) enqueueOBC(obj interface{}) {
+func (c *obcController) enqueueOBC(obj interface{}) {
 	var key string
 	var err error
 	if key, err = cache.MetaNamespaceKeyFunc(obj); err != nil {
@@ -111,7 +111,7 @@ func (c *Controller) enqueueOBC(obj interface{}) {
 	c.queue.AddRateLimited(key)
 }
 
-func (c *Controller) Start(stopCh <-chan struct{}) error {
+func (c *obcController) Start(stopCh <-chan struct{}) error {
 	defer utilruntime.HandleCrash()
 	defer c.queue.ShutDown()
 
@@ -124,12 +124,12 @@ func (c *Controller) Start(stopCh <-chan struct{}) error {
 	return nil
 }
 
-func (c *Controller) runWorker() {
+func (c *obcController) runWorker() {
 	for c.processNextItemInQueue() {
 	}
 }
 
-func (c *Controller) processNextItemInQueue() bool {
+func (c *obcController) processNextItemInQueue() bool {
 	obj, shutdown := c.queue.Get()
 	if shutdown {
 		return false
@@ -179,11 +179,11 @@ func (c *Controller) processNextItemInQueue() bool {
 }
 
 // Reconcile implements the Reconciler interface. This function contains the business logic
-// of the OBC Controller.
+// of the OBC obcController.
 // Note: the obc obtained from the key is not expected to be nil. In other words, this func is
-//   not called when informers detect an object is missing and trigger a formal delete event. 
+//   not called when informers detect an object is missing and trigger a formal delete event.
 //   Instead, delete is indicated by the deletionTimestamp being non-nil on an update event.
-func (c *Controller) syncHandler(key string) error {
+func (c *obcController) syncHandler(key string) error {
 
 	setLoggersWithRequest(key)
 	logD.Info("new Reconcile iteration")
@@ -235,7 +235,7 @@ func (c *Controller) syncHandler(key string) error {
 
 // handleProvision is an extraction of the core provisioning process in order to defer clean up
 // on a provisioning failure
-func (c *Controller) handleProvisionClaim(key string, obc *v1alpha1.ObjectBucketClaim, class *storagev1.StorageClass) (err error) {
+func (c *obcController) handleProvisionClaim(key string, obc *v1alpha1.ObjectBucketClaim, class *storagev1.StorageClass) (err error) {
 
 	var (
 		ob        *v1alpha1.ObjectBucket
@@ -358,7 +358,7 @@ func (c *Controller) handleProvisionClaim(key string, obc *v1alpha1.ObjectBucket
 
 // Delete or Revoke access to bucket defined by passed-in key and obc.
 // TODO each delete should retry a few times to mitigate intermittent errors
-func (c *Controller) handleDeleteClaim(key string, obc *v1alpha1.ObjectBucketClaim) error {
+func (c *obcController) handleDeleteClaim(key string, obc *v1alpha1.ObjectBucketClaim) error {
 	// Call `Delete` for new (greenfield) buckets with reclaimPolicy == "Delete".
 	// Call `Revoke` for new buckets with reclaimPolicy != "Delete".
 	// Call `Revoke` for existing (brownfield) buckets regardless of reclaimPolicy.
@@ -401,13 +401,13 @@ func (c *Controller) handleDeleteClaim(key string, obc *v1alpha1.ObjectBucketCla
 	return c.deleteResources(ob, cm, secret, obc)
 }
 
-func (c *Controller) supportedProvisioner(provisioner string) bool {
+func (c *obcController) supportedProvisioner(provisioner string) bool {
 	return provisioner == c.provisionerName
 }
 
 // Returns the ob, configmap, and secret based on the passed-in key. Only returns non-nil
 // error if unable to get all resources. Some resources may be nil.
-func (c *Controller) getResourcesFromKey(key string) (*v1alpha1.ObjectBucket, *corev1.ConfigMap, *corev1.Secret, error) {
+func (c *obcController) getResourcesFromKey(key string) (*v1alpha1.ObjectBucket, *corev1.ConfigMap, *corev1.Secret, error) {
 
 	ob, obErr := c.objectBucketForClaimKey(key)
 	if errors.IsNotFound(obErr) {
@@ -442,7 +442,7 @@ func (c *Controller) getResourcesFromKey(key string) (*v1alpha1.ObjectBucket, *c
 // is to remove the finalizer on the OBC so it too will be garbage collected.
 // Returns err if we can't delete one or more of the resources, the final returned error being
 // somewhat arbitrary.
-func (c *Controller) deleteResources(ob *v1alpha1.ObjectBucket, cm *corev1.ConfigMap, s *corev1.Secret, obc *v1alpha1.ObjectBucketClaim) (err error) {
+func (c *obcController) deleteResources(ob *v1alpha1.ObjectBucket, cm *corev1.ConfigMap, s *corev1.Secret, obc *v1alpha1.ObjectBucketClaim) (err error) {
 
 	if delErr := deleteObjectBucket(ob, c.libClientset); delErr != nil {
 		log.Error(delErr, "error deleting objectBucket", ob.Name)
@@ -464,7 +464,7 @@ func (c *Controller) deleteResources(ob *v1alpha1.ObjectBucket, cm *corev1.Confi
 }
 
 // Add a finalizer to the OBC so that resource deletion can be orchestrated.
-func (c *Controller) protectOBC(obc *v1alpha1.ObjectBucketClaim) (err error) {
+func (c *obcController) protectOBC(obc *v1alpha1.ObjectBucketClaim) (err error) {
 
 	clib := c.libClientset
 	obcNsName := obc.Namespace + "/" + obc.Name
@@ -482,4 +482,17 @@ func (c *Controller) protectOBC(obc *v1alpha1.ObjectBucketClaim) (err error) {
 	}
 
 	return nil
+}
+
+func (c *obcController) objectBucketForClaimKey(key string) (*v1alpha1.ObjectBucket, error) {
+	logD.Info("getting objectBucket for key", "key", key)
+	name, err := objectBucketNameFromClaimKey(key)
+	if err != nil {
+		return nil, err
+	}
+	ob, err := c.libClientset.ObjectbucketV1alpha1().ObjectBuckets().Get(name, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("error getting object bucket %q: %v", name, err)
+	}
+	return ob, nil
 }

--- a/pkg/provisioner/helpers.go
+++ b/pkg/provisioner/helpers.go
@@ -100,19 +100,6 @@ func isNewBucketByObjectBucket(c kubernetes.Interface, ob *v1alpha1.ObjectBucket
 	return len(class.Parameters[v1alpha1.StorageClassBucket]) == 0
 }
 
-func (c *Controller) objectBucketForClaimKey(key string) (*v1alpha1.ObjectBucket, error) {
-	logD.Info("getting objectBucket for key", "key", key)
-	name, err := objectBucketNameFromClaimKey(key)
-	if err != nil {
-		return nil, err
-	}
-	ob, err := c.libClientset.ObjectbucketV1alpha1().ObjectBuckets().Get(name, metav1.GetOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("error getting object bucket %q: %v", name, err)
-	}
-	return ob, nil
-}
-
 func configMapForClaimKey(key string, c kubernetes.Interface) (*corev1.ConfigMap, error) {
 	logD.Info("getting configMap for key", "key", key)
 	ns, name, err := cache.SplitMetaNamespaceKey(key)

--- a/pkg/provisioner/manager.go
+++ b/pkg/provisioner/manager.go
@@ -29,15 +29,12 @@ import (
 	"github.com/kube-object-storage/lib-bucket-provisioner/pkg/provisioner/api"
 )
 
-// Controller is the first iteration of our internal provisioning
-// Controller.  The passed-in bucket provisioner, coded by the user of the
-// library, is stored for later Provision and Delete calls.
+// Provisioner wraps a custom controller which watches OBCs and manages OB, CMs, and Secrets.
 type Provisioner struct {
 	Name            string
 	Provisioner     api.Provisioner
 	claimController controller
 	informerFactory informers.SharedInformerFactory
-	// TODO context?
 }
 
 func initLoggers() {
@@ -62,7 +59,7 @@ func initFlags() {
 }
 
 // NewProvisioner should be called by importers of this library to
-// instantiate a new provisioning Controller. This Controller will
+// instantiate a new provisioning obcController. This obcController will
 // respond to Add / Update / Delete events by calling the passed-in
 // provisioner's Provisioner and Delete methods.
 // The Provisioner will be restrict to operating only to the namespace given
@@ -84,7 +81,7 @@ func NewProvisioner(
 	p := &Provisioner{
 		Name:            provisionerName,
 		informerFactory: informerFactory,
-		claimController: NewController(provisionerName, provisioner, clientset, libClientset,
+		claimController: newController(provisionerName, provisioner, clientset, libClientset,
 			informerFactory.Objectbucket().V1alpha1().ObjectBucketClaims(),
 			informerFactory.Objectbucket().V1alpha1().ObjectBuckets()),
 	}


### PR DESCRIPTION
The libraries internal controller was once exported because it was under a separate package from the manager.  Once the project was flattened to its current state, there is no need to export the controller.

Signed-off-by: Jon Cope <jcope@redhat.com>