### PR TITLE
Fix infinite deletion loops and lock ups

### DIFF
--- a/pkg/provisioner/controller.go
+++ b/pkg/provisioner/controller.go
@@ -419,7 +419,7 @@ func (c *obcController) handleDeleteClaim(key string, obc *v1alpha1.ObjectBucket
 
 	log.Info("syncing obc deletion")
 
-	ob, cm, secret, errs := c.getResourcesForDeletionByKey(key)
+	ob, cm, secret, errs := c.getExistingResourcesFromKey(key)
 	if len(errs) > 0 {
 		return fmt.Errorf("error getting resources: %v", errs)
 	}
@@ -463,7 +463,7 @@ func (c *obcController) supportedProvisioner(provisioner string) bool {
 }
 
 // trim the errors resulting from objects not being found
-func (c *obcController) getResourcesForDeletionByKey(key string) (*v1alpha1.ObjectBucket, *corev1.ConfigMap, *corev1.Secret, []error) {
+func (c *obcController) getExistingResourcesFromKey(key string) (*v1alpha1.ObjectBucket, *corev1.ConfigMap, *corev1.Secret, []error) {
 	ob, cm, secret, errs := c.getResourcesFromKey(key)
 	for i := len(errs) - 1; i >= 0; i-- {
 		if errors.IsNotFound(errs[i]) {
@@ -479,6 +479,7 @@ func (c *obcController) getResourcesForDeletionByKey(key string) (*v1alpha1.Obje
 func (c *obcController) getResourcesFromKey(key string) (ob *v1alpha1.ObjectBucket, cm *corev1.ConfigMap, sec *corev1.Secret, errs []error) {
 
 	var err error
+	// The cap(errs) must be large enough to encapsulate errors returned by all 3 *ForClaimKey funcs
 	errs = make([]error, 0, 3)
 	groupErrors := func(err error) {
 		if err != nil {

--- a/pkg/provisioner/controller.go
+++ b/pkg/provisioner/controller.go
@@ -200,28 +200,23 @@ func (c *obcController) processNextItemInQueue() bool {
 func (c *obcController) syncHandler(key string) error {
 
 	setLoggersWithRequest(key)
-	logD.Info("new Reconcile iteration")
+	logD.Info("reconciling claim")
 
 	obc, err := claimForKey(key, c.libClientset)
 	if err != nil {
-		return fmt.Errorf("request key %q: %v", key, err)
-	}
-	if obc == nil {
-		return fmt.Errorf("unexpected nil obc for request key %q", key)
-	}
-
-	deleteEvent := obc.ObjectMeta.DeletionTimestamp != nil
-
-	if deleteEvent {
-		// ***********************
-		// Delete or Revoke Bucket
-		// ***********************
-		log.Info("OBC deleted, proceeding with cleanup")
-		err = c.handleDeleteClaim(key, obc)
-		if err != nil {
-			log.Error(err, "error cleaning up OBC", "name", key)
+		if errors.IsNotFound(err) {
+			log.Info("OBC vanished, assuming it was deleted")
+			return nil
 		}
-		return err
+		return fmt.Errorf("could not sync OBC: %v", err)
+	}
+
+	// ***********************
+	// Delete or Revoke Bucket
+	// ***********************
+	if obc.ObjectMeta.DeletionTimestamp != nil {
+		log.Info("OBC deleted, proceeding with cleanup")
+		return c.handleDeleteClaim(key, obc)
 	}
 
 	// *******************************************************
@@ -261,12 +256,15 @@ func (c *obcController) syncHandler(key string) error {
 
 // handleProvision is an extraction of the core provisioning process in order to defer clean up
 // on a provisioning failure
-func (c *obcController) handleProvisionClaim(key string, obc *v1alpha1.ObjectBucketClaim, class *storagev1.StorageClass) (err error) {
+func (c *obcController) handleProvisionClaim(key string, obc *v1alpha1.ObjectBucketClaim, class *storagev1.StorageClass) error {
+
+	log.Info("syncing obc creation")
 
 	var (
 		ob        *v1alpha1.ObjectBucket
 		secret    *corev1.Secret
 		configMap *corev1.ConfigMap
+		err       error
 	)
 
 	// set finalizer in OBC so that resources cleaned up is controlled when the obc is deleted
@@ -283,7 +281,7 @@ func (c *obcController) handleProvisionClaim(key string, obc *v1alpha1.ObjectBuc
 	// It is assumed that if the get claim fails, no resources were generated to begin with.
 	defer func() {
 		if err != nil {
-			log.Error(err, "cleaning up reconcile artifacts")
+			log.Info("provisioning errored, cleaning up API resources")
 			if !pErr.IsBucketExists(err) && ob != nil && isDynamicProvisioning {
 				log.Info("deleting storage artifacts")
 				if err = c.provisioner.Delete(ob); err != nil {
@@ -414,14 +412,16 @@ func (c *obcController) handleProvisionClaim(key string, obc *v1alpha1.ObjectBuc
 }
 
 // Delete or Revoke access to bucket defined by passed-in key and obc.
-// TODO each delete should retry a few times to mitigate intermittent errors
 func (c *obcController) handleDeleteClaim(key string, obc *v1alpha1.ObjectBucketClaim) error {
 	// Call `Delete` for new (greenfield) buckets with reclaimPolicy == "Delete".
 	// Call `Revoke` for new buckets with reclaimPolicy != "Delete".
 	// Call `Revoke` for existing (brownfield) buckets regardless of reclaimPolicy.
-	ob, cm, secret, err := c.getResourcesFromKey(key)
-	if err != nil {
-		return err
+
+	log.Info("syncing obc deletion")
+
+	ob, cm, secret, errs := c.getResourcesForDeletionByKey(key)
+	if len(errs) > 0 {
+		return fmt.Errorf("error getting resources: %v", errs)
 	}
 
 	// Delete/Revoke cannot be called if the ob is nil; however, if the secret
@@ -438,7 +438,7 @@ func (c *obcController) handleDeleteClaim(key string, obc *v1alpha1.ObjectBucket
 
 	// call Delete or Revoke and then delete generated k8s resources
 	// Note: if Delete or Revoke return err then we do not try to delete resources
-	ob, err = updateObjectBucketPhase(c.libClientset, ob, v1alpha1.ObjectBucketClaimStatusPhaseReleased, defaultRetryBaseInterval, defaultRetryTimeout)
+	ob, err := updateObjectBucketPhase(c.libClientset, ob, v1alpha1.ObjectBucketClaimStatusPhaseReleased, defaultRetryBaseInterval, defaultRetryTimeout)
 	if err != nil {
 		return err
 	}
@@ -462,33 +462,38 @@ func (c *obcController) supportedProvisioner(provisioner string) bool {
 	return provisioner == c.provisionerName
 }
 
-// Returns the ob, configmap, and secret based on the passed-in key. Only returns non-nil
-// error if unable to get all resources. Some resources may be nil.
-func (c *obcController) getResourcesFromKey(key string) (*v1alpha1.ObjectBucket, *corev1.ConfigMap, *corev1.Secret, error) {
+// trim the errors resulting from objects not being found
+func (c *obcController) getResourcesForDeletionByKey(key string) (*v1alpha1.ObjectBucket, *corev1.ConfigMap, *corev1.Secret, []error) {
+	ob, cm, secret, errs := c.getResourcesFromKey(key)
+	for i := len(errs) - 1; i >= 0; i-- {
+		if errors.IsNotFound(errs[i]) {
+			errs = append(errs[:i], errs[i+1:]...)
+		}
+	}
+	return ob, cm, secret, errs
+}
 
-	ob, obErr := c.objectBucketForClaimKey(key)
-	if errors.IsNotFound(obErr) {
-		log.Error(obErr, "objectBucket not found")
-		obErr = nil
-	}
-	cm, cmErr := configMapForClaimKey(key, c.clientset)
-	if errors.IsNotFound(cmErr) {
-		log.Error(cmErr, "configMap not found")
-		cmErr = nil
-	}
-	s, sErr := secretForClaimKey(key, c.clientset)
-	if errors.IsNotFound(sErr) {
-		log.Error(sErr, "secret not found")
-		sErr = nil
-	}
+// Gathers resources by names derived from key.
+// Returns pointers to those resources if they exist, nil otherwise and an slice of errors who's
+// len() == n errors. If no errors occur, len() is 0.
+func (c *obcController) getResourcesFromKey(key string) (ob *v1alpha1.ObjectBucket, cm *corev1.ConfigMap, sec *corev1.Secret, errs []error) {
 
 	var err error
-	// return err if all resources were not retrieved, else no error
-	if obErr != nil && cmErr != nil && sErr != nil {
-		err = fmt.Errorf("could not get all needed resources: %v : %v : %v", obErr, cmErr, sErr)
+	errs = make([]error, 0, 3)
+	groupErrors := func(err error) {
+		if err != nil {
+			errs = append(errs, err)
+		}
 	}
 
-	return ob, cm, s, err
+	ob, err = c.objectBucketForClaimKey(key)
+	groupErrors(err)
+	cm, err = configMapForClaimKey(key, c.clientset)
+	groupErrors(err)
+	sec, err = secretForClaimKey(key, c.clientset)
+	groupErrors(err)
+
+	return
 }
 
 // Deleting the resources generated by a Provision or Grant call is triggered by the delete of
@@ -550,7 +555,7 @@ func (c *obcController) objectBucketForClaimKey(key string) (*v1alpha1.ObjectBuc
 	}
 	ob, err := c.libClientset.ObjectbucketV1alpha1().ObjectBuckets().Get(name, metav1.GetOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("error getting object bucket %q: %v", name, err)
+		return nil, err
 	}
 	return ob, nil
 }

--- a/pkg/provisioner/controller.go
+++ b/pkg/provisioner/controller.go
@@ -208,7 +208,7 @@ func (c *obcController) syncHandler(key string) error {
 			log.Info("OBC vanished, assuming it was deleted")
 			return nil
 		}
-		return fmt.Errorf("could not sync OBC: %v", err)
+		return fmt.Errorf("could not sync OBC %s: %v", key, err)
 	}
 
 	// ***********************

--- a/pkg/provisioner/helpers.go
+++ b/pkg/provisioner/helpers.go
@@ -60,7 +60,7 @@ func makeOwnerReference(claim *v1alpha1.ObjectBucketClaim) metav1.OwnerReference
 }
 
 func shouldProvision(obc *v1alpha1.ObjectBucketClaim) bool {
-	logD.Info("validating claim for provisioning obc", obc.Name)
+	logD.Info("checking OBC for OB name, this indicates provisioning is complete", obc.Name)
 	if obc.Spec.ObjectBucketName != "" {
 		log.Info("provisioning already completed", "ObjectBucket", obc.Spec.ObjectBucketName)
 		return false

--- a/pkg/provisioner/helpers.go
+++ b/pkg/provisioner/helpers.go
@@ -110,7 +110,7 @@ func configMapForClaimKey(key string, c kubernetes.Interface) (*corev1.ConfigMap
 	}
 	cm, err := c.CoreV1().ConfigMaps(ns).Get(name, metav1.GetOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("error getting configmap %q: %v", ns+"/"+name, err)
+		return nil, err
 	}
 	return cm, nil
 }
@@ -123,7 +123,7 @@ func secretForClaimKey(key string, c kubernetes.Interface) (sec *corev1.Secret, 
 	}
 	sec, err = c.CoreV1().Secrets(ns).Get(name, metav1.GetOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("error getting secret %q: %v", ns+"/"+name, err)
+		return nil, err
 	}
 	return
 }

--- a/pkg/provisioner/resourcehandlers.go
+++ b/pkg/provisioner/resourcehandlers.go
@@ -299,7 +299,7 @@ func updateObjectBucketPhase(c versioned.Interface, ob *v1alpha1.ObjectBucket, p
 
 	err = wait.PollImmediate(retryInterval, retryTimeout, func() (bool, error) {
 		result, err = c.ObjectbucketV1alpha1().ObjectBuckets().UpdateStatus(ob)
-		return (err == nil), err
+		return err == nil, err
 	})
 	return
 }


### PR DESCRIPTION
This PR address a couple OBC deletion related issues.

1. When an OBC is deleted before a finalizer can be placed on it, the IsNotFound error is now ignored.  The assumption is safe because, if the finalized had been set, then the OBC would not have vanished and thus the OBC would have been found.  Once the finalizer is place, it is only removed once all resources are cleaned up.  Thus, it is only possible for OBC to vanish in this small window if it was never processed to begin with. 

2. When resources cannot be found for deletion, IsNotFound errors are ignored.  In cases where a secret, cm, or ob are not found, continue on with deleting the rest of the resources and do not report the errors.

Signed-off-by: jcope <jcope@redhat.com>