### PR TITLE
api: add kubebuilder marker for scope

### DIFF
--- a/pkg/apis/objectbucket.io/v1alpha1/objectbucket_types.go
+++ b/pkg/apis/objectbucket.io/v1alpha1/objectbucket_types.go
@@ -127,13 +127,14 @@ const (
 
 // ObjectBucketStatus defines the observed state of ObjectBucket
 type ObjectBucketStatus struct {
-	Phase      ObjectBucketStatusPhase `json:"phase"`
+	Phase ObjectBucketStatusPhase `json:"phase"`
 }
 
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:openapi-gen=true
+// +kubebuilder:resource:scope=Cluster
 // +kubebuilder:printcolumn:name="StorageClass",type="string",JSONPath=".spec.storageClassName",description="StorageClass"
 // +kubebuilder:printcolumn:name="ClaimNamespace",type="string",JSONPath=".spec.claimRef.namespace",description="ClaimNamespace"
 // +kubebuilder:printcolumn:name="ClaimName",type="string",JSONPath=".spec.claimRef.name",description="ClaimName"


### PR DESCRIPTION
Kubebuiler will apply the "Namespaced" scope by default if not specified
otherwise. The ObjectBucket resource is Cluster scoped so we need to
force that.

Signed-off-by: Sébastien Han <seb@redhat.com>