### PR TITLE
api: add kubebuilder markers

### DIFF
--- a/pkg/apis/objectbucket.io/v1alpha1/objectbucket_types.go
+++ b/pkg/apis/objectbucket.io/v1alpha1/objectbucket_types.go
@@ -135,6 +135,7 @@ type ObjectBucketStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:openapi-gen=true
 // +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:shortName=ob;obs
 // +kubebuilder:printcolumn:name="StorageClass",type="string",JSONPath=".spec.storageClassName",description="StorageClass"
 // +kubebuilder:printcolumn:name="ClaimNamespace",type="string",JSONPath=".spec.claimRef.namespace",description="ClaimNamespace"
 // +kubebuilder:printcolumn:name="ClaimName",type="string",JSONPath=".spec.claimRef.name",description="ClaimName"

--- a/pkg/apis/objectbucket.io/v1alpha1/objectbucketclaim_types.go
+++ b/pkg/apis/objectbucket.io/v1alpha1/objectbucketclaim_types.go
@@ -81,6 +81,7 @@ type ObjectBucketClaimStatus struct {
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:openapi-gen=true
+// +kubebuilder:resource:shortName=obc;obcs
 // +kubebuilder:printcolumn:name="StorageClass",type="string",JSONPath=".spec.storageClassName",description="StorageClass"
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="Phase"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"


### PR DESCRIPTION
More markers are needed to get a correct generation, especially for
shortnames.
Rook will fail with unknown resource if we don't do this.

Signed-off-by: Sébastien Han <seb@redhat.com>