### PR TITLE
api: fix resource marker for kubebuilder

### DIFF
--- a/pkg/apis/objectbucket.io/v1alpha1/objectbucket_types.go
+++ b/pkg/apis/objectbucket.io/v1alpha1/objectbucket_types.go
@@ -134,8 +134,7 @@ type ObjectBucketStatus struct {
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:openapi-gen=true
-// +kubebuilder:resource:scope=Cluster
-// +kubebuilder:resource:shortName=ob;obs
+// +kubebuilder:resource:scope=Cluster,shortName=ob;obs
 // +kubebuilder:printcolumn:name="StorageClass",type="string",JSONPath=".spec.storageClassName",description="StorageClass"
 // +kubebuilder:printcolumn:name="ClaimNamespace",type="string",JSONPath=".spec.claimRef.namespace",description="ClaimNamespace"
 // +kubebuilder:printcolumn:name="ClaimName",type="string",JSONPath=".spec.claimRef.name",description="ClaimName"


### PR DESCRIPTION
We expect all the resource to be on the same marker line.

Signed-off-by: Sébastien Han <seb@redhat.com>