### PR TITLE
api: add api support for Update events

### DIFF
--- a/pkg/provisioner/api/provisioner.go
+++ b/pkg/provisioner/api/provisioner.go
@@ -43,6 +43,8 @@ type Provisioner interface {
 	Provision(options *BucketOptions) (*v1alpha1.ObjectBucket, error)
 	// Grant should be implemented to handle access to existing buckets
 	Grant(options *BucketOptions) (*v1alpha1.ObjectBucket, error)
+	// Update should be implemented to handle cases when additional config are modified
+	Update(ob *v1alpha1.ObjectBucket) error
 	// Delete should be implemented to handle bucket deletion
 	Delete(ob *v1alpha1.ObjectBucket) error
 	// Revoke should be implemented to handle removing bucket access

--- a/pkg/provisioner/fakeinterface_test.go
+++ b/pkg/provisioner/fakeinterface_test.go
@@ -59,3 +59,11 @@ func (p *fakeProvisioner) Revoke(ob *v1alpha1.ObjectBucket) (err error) {
 	}
 	return err
 }
+
+// Update provides a simple method for testing purposes
+func (p *fakeProvisioner) Update(ob *v1alpha1.ObjectBucket) (err error) {
+	if ob == nil {
+		err = fmt.Errorf("got nil object bucket pointer")
+	}
+	return err
+}


### PR DESCRIPTION
Adding support to handle Update Events of OBC, currently `AdditionalConfig` needs this change.
Other fields are immutable
Fixes #195
Signed-off-by: Jiffin Tony Thottan <thottanjiffin@gmail.com>