### PR TITLE
fix OBC delete stuck

### DIFF
--- a/pkg/provisioner/controller.go
+++ b/pkg/provisioner/controller.go
@@ -650,6 +650,13 @@ func (c *obcController) objectBucketForClaimKey(key string) (*v1alpha1.ObjectBuc
 }
 
 func updateSupported(old, new *v1alpha1.ObjectBucketClaim) bool {
+
+	// Deletiong stamp is set, so return true so that it will be added
+	// to queue for deletion
+	if new.ObjectMeta.DeletionTimestamp != nil {
+		return true
+	}
+
 	// The only field supported for update is obc.spec.additionalConfig
 	if reflect.DeepEqual(new.Spec, old.Spec) {
 		return false


### PR DESCRIPTION
The delete operation is handled via update calls, with addition of new
Update() API, the objects need to deleted are not added to the queue due
to check in updateSupported(). So if the deletion timestamp is set, then
this check is ignored in NewController().
FInd more details [here](https://github.com/rook/rook/pull/8514#issuecomment-898011184)

Signed-off-by: Jiffin Tony Thottan <thottanjiffin@gmail.com>