### PR TITLE
handle go routine execution error

### DIFF
--- a/pkg/provisioner/manager.go
+++ b/pkg/provisioner/manager.go
@@ -140,10 +140,14 @@ func (p *Provisioner) RunWithContext(context context.Context) (err error) {
 		err = p.claimController.Start(stopCh)
 	}()
 
-	<-context.Done()
-	close(stopCh)
-	log.Info("stopping provisioner", "name", p.Name, "reason", context.Err())
-	return nil
+	select {
+	case <-stopCh:
+		return err
+	case <-context.Done():
+		close(stopCh)
+		log.Info("stopping provisioner", "name", p.Name, "reason", context.Err())
+		return nil
+	}
 }
 
 // setupInformerFactory generates an informer factory scoped to the given namespace if provided or


### PR DESCRIPTION
Prior to this, RunWithContext would block and wait for the context to be
cancelled and error handling of the go routine was lost since the
channel was never read again.
Now we check if the channel has an error and return. Also if the context
is terminated we close the channel and return.

Signed-off-by: Sébastien Han <seb@redhat.com>