### PR TITLE
fixed bug in generateBucketName

### DIFF
--- a/pkg/provisioner/helpers.go
+++ b/pkg/provisioner/helpers.go
@@ -197,7 +197,7 @@ const (
 )
 
 func generateBucketName(prefix string) string {
-	if len(prefix) > maxBaseNameLen {
+	if len(prefix) >= maxBaseNameLen {
 		prefix = prefix[:maxBaseNameLen-1]
 	}
 	return fmt.Sprintf("%s-%s", prefix, uuid.New())


### PR DESCRIPTION
when the prefix length is exactly maxBaseNameLen, the prefix is not truncated and as a result, the generated bucket name is invalid.


Signed-off-by: Danny Zaken <dannyzaken@gmail.com>