### PR TITLE
BREAKING! allow OBs to be updated by provisioner

### DIFF
--- a/pkg/provisioner/fakeinterface_test.go
+++ b/pkg/provisioner/fakeinterface_test.go
@@ -28,6 +28,13 @@ type fakeProvisioner struct{}
 
 var _ api.Provisioner = &fakeProvisioner{}
 
+func (p *fakeProvisioner) GenerateUserID(obc *v1alpha1.ObjectBucketClaim, ob *v1alpha1.ObjectBucket) (string, error) {
+	if obc == nil {
+		return "", fmt.Errorf("got nil ptr")
+	}
+	return "fake-obc-" + obc.Namespace + "-" + obc.Name, nil
+}
+
 // Provision provides a simple method for testing purposes
 func (p *fakeProvisioner) Provision(options *api.BucketOptions) (*v1alpha1.ObjectBucket, error) {
 	if options == nil || options.ObjectBucketClaim == nil {
@@ -54,14 +61,6 @@ func (p *fakeProvisioner) Delete(ob *v1alpha1.ObjectBucket) (err error) {
 
 // Revoke provides a simple method for testing purposes
 func (p *fakeProvisioner) Revoke(ob *v1alpha1.ObjectBucket) (err error) {
-	if ob == nil {
-		err = fmt.Errorf("got nil object bucket pointer")
-	}
-	return err
-}
-
-// Update provides a simple method for testing purposes
-func (p *fakeProvisioner) Update(ob *v1alpha1.ObjectBucket) (err error) {
 	if ob == nil {
 		err = fmt.Errorf("got nil object bucket pointer")
 	}


### PR DESCRIPTION
THIS IS A BREAKING CHANGE!

Sometimes, an OB might need to be updated by the provisioner. For example, the endpoint of the object store changed.

In order for this to work, lib-bucket-provisioner must use an idempotent controller, and it must call Provision()/Grant() on each reconcile. Provision() and Grant() must then also be idempotent. In order to allow these calls to be more idempotent, l-b-p will now call GenerateUserID() to generate a deterministic idempotency key that Provision() and Grant() will then use as a user name and for any actions that need help being idempotent between runs.

Because Provision() and Grant() are idempotent, there is now no need for the Update() method.

This is a change to the previous API spec which allowed provisioners to return errors if a bucket already existed in the backend.

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>