### PR TITLE
ObjectBucketName in OBC spec is missing

### DIFF
--- a/pkg/provisioner/controller.go
+++ b/pkg/provisioner/controller.go
@@ -284,6 +284,18 @@ func (c *obcController) handleProvisionClaim(key string, obc *v1alpha1.ObjectBuc
 		return fmt.Errorf("failed to find ob associated with obc %q", obc.Name)
 	}
 
+	// If ObjectBucket exists but objectBucketName is missing, restore it
+	// Only restore if the OB is in a valid state: Phase is Bound
+	if ob != nil && obc.Spec.ObjectBucketName == "" &&
+		ob.Status.Phase == v1alpha1.ObjectBucketStatusPhaseBound {
+		log.Info("restoring missing objectBucketName in OBC", "obc", obc.Name, "ob", ob.Name)
+		obc.Spec.ObjectBucketName = ob.Name
+		obc, err = updateClaim(c.libClientset, obc)
+		if err != nil {
+			return fmt.Errorf("error restoring objectBucketName in OBC: %v", err)
+		}
+	}
+
 	// on an operator restart, the event will be an add event, and we should check if the obc has
 	// been updated in comparison to the ob, since we don't have an old OBC to compare to
 	if err = errIfObcConfigHasBeenModified(ob, obc); err != nil {
@@ -583,6 +595,14 @@ func updateSupported(old, new *v1alpha1.ObjectBucketClaim) bool {
 	if reflect.DeepEqual(new.Spec, old.Spec) {
 		return false
 	}
+
+	// CRITICAL: Prevent modification of objectBucketName once set
+	if old.Spec.ObjectBucketName != "" && new.Spec.ObjectBucketName != old.Spec.ObjectBucketName {
+		log.Error(nil, "invalid changes to OBC: objectBucketName cannot be modified once set",
+			"old", old.Spec.ObjectBucketName, "new", new.Spec.ObjectBucketName)
+		return false
+	}
+
 	// create copy of old spec, and set the new spec's additionalConfig on it
 	oldspec := old.Spec.DeepCopy()
 	oldspec.AdditionalConfig = new.Spec.AdditionalConfig


### PR DESCRIPTION
### Explain the changes
created a PR to fix this there are two changes

1. Add validation to prevent external components from modifying the objectBucketName field once it's set
2. Add reconciliation logic to restore the objectBucketName if it's removed

### Issues: Fixed #xxx / Gap #xxx
1. https://redhat.atlassian.net/browse/DFBUGS-2323

### Testing Instructions:
1. Create an OBC backed by NooBaa
3. Wait for it to be Bound
4. Remove `objectBucketName` from OBC spec and verify

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the objectBucketName field could remain missing in Bound ObjectBucketClaim resources. The system now automatically restores this missing spec field during update operations when a claim is in Bound status, ensuring consistent and complete claim configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->